### PR TITLE
Replace `ralbot-html` with `peakrdl_html`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ clean:
 	rm -rf ./output
 
 deps:
-	pip3 install ralbot-html
+	pip3 install peakrdl-html
 	pip3 install systemrdl-compiler

--- a/gen_docs.py
+++ b/gen_docs.py
@@ -10,7 +10,7 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(this_dir, "./"))
 
 from systemrdl import RDLCompiler, RDLCompileError
-from ralbot.html import HTMLExporter
+from peakrdl_html import HTMLExporter
 
 #===============================================================================
 #input_file = sys.argv[1]


### PR DESCRIPTION
[`ralbot-html`](https://github.com/RasmusGOlsen/RALBot-html/tree/master) isn't maintained anymore.

Last commit was in 2019, and PyPi doesn't have the package for it anymore.

Switch to the compatible [`peakrdl-html`](https://github.com/SystemRDL/PeakRDL-html), which is maintained.

Tested.